### PR TITLE
Fix subscription cleanup

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -24,7 +24,7 @@ body{font-family: Arial, Helvetica, sans-serif;}
     }
 }
 .chatBox {
-    border: 5px solid dark black;
+    border: 5px solid black;
     border-radius: 5px;
     width: 640px;
     height: 400px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,7 @@ export default function App() {
     
     
 
-    const channels = supabase.channel('chat-channel')
+    const channel = supabase.channel('chat-channel')
     .on(
       'postgres_changes',
       { event: 'INSERT', schema: 'public', table: 'chats' },
@@ -35,6 +35,10 @@ export default function App() {
       }
     )
     .subscribe()
+
+    return () => {
+      supabase.removeChannel(channel)
+    }
   }, []);
 
   async function handleSubmit(e) {


### PR DESCRIPTION
## Summary
- clean up Supabase channel when component unmounts
- fix invalid CSS color definition

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e2ee177483308e3fa61e76a9a461